### PR TITLE
Coverage

### DIFF
--- a/geobuf/decode.py
+++ b/geobuf/decode.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import collections
@@ -182,8 +181,6 @@ class Decoder:
 
 
     def decode_multi_polygon(self, geometry):
-        if len(geometry.lengths) == 0:
-            return [[self.decode_line(geometry.coords)]]
 
         obj = []
         i = 0
@@ -201,10 +198,3 @@ class Decoder:
                 i += l * d
             obj.append(rings)
         return obj
-
-
-if __name__ == "__main__":
-    filename = sys.argv[1]
-    data_str = open(filename,'rb').read()
-    obj = Decoder().decode(data_str)
-    open(filename.replace('.pbf', '.pbf.json'), 'wb').write(json.dumps(obj))

--- a/geobuf/encode.py
+++ b/geobuf/encode.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import collections
@@ -154,8 +153,9 @@ class Encoder:
         elif isinstance(val, float):
             if val.is_integer(): self.encode_int(int(val), value)
             else: value.double_value = val
-        elif isinstance(val, int) or isinstance(val, long): self.encode_int(val, value)
         elif isinstance(val, bool): value.bool_value = val
+        elif isinstance(val, int) or isinstance(val, long): self.encode_int(val, value)
+
 
         properties.append(keyIndex)
         properties.append(len(values) - 1)
@@ -203,21 +203,3 @@ class Encoder:
 
         for rings in polygons:
             for points in rings: self.add_line(geometry.coords, points)
-
-
-if __name__ == '__main__':
-    filename = sys.argv[1]
-    data = open(filename,'rb').read()
-    json_object = json.loads(data)
-
-    if len(sys.argv) > 3:
-        proto = Encoder().encode(json_object, int(sys.argv[2]), int(sys.argv[3]))
-    elif len(sys.argv) > 2:
-        proto = Encoder().encode(json_object, int(sys.argv[2]))
-    else:
-        proto = Encoder().encode(json_object)
-
-    print "Encoded in %d bytes out of %d (%d)" % (
-        len(proto), len(data), 100 * len(proto) / len(data))
-
-    open(filename.replace('.json', '.pbf'), 'wb').write(proto)

--- a/test/fixtures/props.json
+++ b/test/fixtures/props.json
@@ -21,6 +21,7 @@
         "properties": {
             "string": "foo",
             "int": 5,
+            "neg_int": -5,
             "float": 123.456,
             "bool": false,
             "empty": "",

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3,6 +3,7 @@ import os.path
 from click.testing import CliRunner
 import pytest
 
+import geobuf
 from geobuf.scripts.cli import cli
 
 
@@ -10,6 +11,24 @@ from geobuf.scripts.cli import cli
 def props_json():
     return open(
         os.path.join(os.path.dirname(__file__), "fixtures/props.json")).read()
+
+
+def test_cli_version():
+    runner = CliRunner()
+    result = runner.invoke(cli, ['--version'])
+    assert result.output.strip() == geobuf.__version__
+
+
+def test_cli_encode_err():
+    runner = CliRunner()
+    result = runner.invoke(cli, ['encode'], "0")
+    assert result.exit_code == 1
+
+
+def test_cli_decode_err():
+    runner = CliRunner()
+    result = runner.invoke(cli, ['decode'], "0")
+    assert result.exit_code == 1
 
 
 def test_cli_roundtrip(props_json):


### PR DESCRIPTION
De-scriptifies the encode and decode modules now that we have a CLI. Adds more CLI tests. Dodges this gotcha:

```python
>>> isinstance(True, int)
True
```

100% code coverage.