### PR TITLE
Fix issue #31 : 'long' does not exist in python3

### DIFF
--- a/geobuf/encode.py
+++ b/geobuf/encode.py
@@ -156,7 +156,7 @@ class Encoder:
             if val.is_integer(): self.encode_int(int(val), value)
             else: value.double_value = val
         elif isinstance(val, bool): value.bool_value = val
-        elif isinstance(val, int) or isinstance(val, long): self.encode_int(val, value)
+        elif isinstance(val, six.integer_types): self.encode_int(val, value)
 
 
         properties.append(keyIndex)


### PR DESCRIPTION
This fixes issue #31 .

On a side note : this error did not crop up in the testsuite, because it does not exercise the implicit final "else" in the if/elif block. Adding a "null" (None) value to test/fixtures/props.json does trigger the error reported in #31.