### PR TITLE
Fix py3 support in encode_property for integer types

### DIFF
--- a/geobuf/encode.py
+++ b/geobuf/encode.py
@@ -2,7 +2,6 @@
 
 import collections
 import json
-import sys
 
 import six
 
@@ -156,7 +155,7 @@ class Encoder:
             if val.is_integer(): self.encode_int(int(val), value)
             else: value.double_value = val
         elif isinstance(val, bool): value.bool_value = val
-        elif isinstance(val, int) or isinstance(val, long): self.encode_int(val, value)
+        elif isinstance(val, six.integer_types): self.encode_int(val, value)
 
 
         properties.append(keyIndex)


### PR DESCRIPTION
`encode_property` checks for `long` types, which were removed in py3. This leverages `six.integer_types` in `isinstance` instead.